### PR TITLE
Add AI Interview Coach for Engineering Leaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository aims at providing collated content at a single place to prepare 
 - [System Design/High Level Design](https://github.com/imkgarg/Software-Engineering-Interview-Primer/blob/master/SystemDesign.md)
 - [CS Fundamentals](https://github.com/imkgarg/Awesome-Software-Engineering-Interview/blob/master/CSFundamentals.md)
 - [Behavioral](https://github.com/imkgarg/Awesome-Software-Engineering-Interview/blob/master/Behavioral.md)
+- [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers
 
 ## Under development
 


### PR DESCRIPTION
## Add AI Interview Coach for Engineering Leaders

[AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice built for software engineers and engineering managers. 130+ role-specific questions, STAR-format scoring across 6 dimensions, probing follow-ups, and 3 interviewer personas (Startup CTO, Big Tech VP, Scale-up Director). Free first question.