### PR TITLE
Add PracHub system design question bank to System Design resources

### DIFF
--- a/SystemDesign.md
+++ b/SystemDesign.md
@@ -68,6 +68,8 @@
 - [Design YouTube / Netflix](https://medium.com/@eileen.code4fun/system-design-interview-mini-youtube-5cae5eedceae)
 - [Design Web Crawler](https://medium.com/@morefree7/design-a-distributed-web-crawler-f67a8ebb8336)
 
+- [PracHub — System Design Interview Questions](https://prachub.com/categories/system-design) - Searchable bank of real system design interview questions with worked solutions and discussion.
+
 ## Database internals
 
 ### Cassandra


### PR DESCRIPTION
Adds PracHub's system design interview question bank to **SystemDesign.md → Actual Questions**, as an additional source of practice questions alongside the individual design problems already listed.

**Link:** https://prachub.com/categories/system-design — a searchable collection of real system design interview questions with worked solutions and community discussion.

- New addition, dedup-checked against existing entries
- Placed at the bottom of the Actual Questions section
